### PR TITLE
Add FocoFinalizado flow regression test with custom DOM harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fokus-projeto-base",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "node tests/focoFinalizado.test.js"
+  }
+}

--- a/tests/focoFinalizado.test.js
+++ b/tests/focoFinalizado.test.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert');
+const path = require('node:path');
+const { createDomEnvironment } = require('./helpers/mockDom');
+
+function runTest(name, testFn) {
+  try {
+    testFn();
+    console.log(`✅ ${name}`);
+  } catch (error) {
+    console.error(`❌ ${name}`);
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  }
+}
+
+runTest('FocoFinalizado marca a tarefa selecionada como concluída e persiste no armazenamento', () => {
+  const environment = createDomEnvironment();
+  environment.applyGlobals();
+
+  const scriptPath = path.join(__dirname, '..', 'script-crud.js');
+  delete require.cache[require.resolve(scriptPath)];
+
+  try {
+    require(scriptPath);
+
+    const { document, window } = environment;
+    const textarea = document.querySelector('.app__form-textarea');
+    textarea.value = 'Estudar testes automatizados';
+
+    const form = document.querySelector('.app__form-add-task');
+    form.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
+
+    const taskItem = document.querySelector('.app__section-task-list-item');
+    if (!taskItem) {
+      throw new Error('A tarefa não foi criada após o envio do formulário');
+    }
+
+    taskItem.click();
+
+    document.dispatchEvent(new window.CustomEvent('FocoFinalizado'));
+
+    assert(
+      taskItem.classList.contains('app__section-task-list-item-complete'),
+      'A tarefa selecionada deve receber a classe de completa'
+    );
+    assert(
+      !taskItem.classList.contains('app__section-task-list-item-active'),
+      'A tarefa selecionada não deve permanecer com a classe de ativa após concluir'
+    );
+
+    const editButton = taskItem.querySelector('button');
+    assert(editButton, 'O botão de edição precisa existir dentro da tarefa');
+    assert.strictEqual(editButton.getAttribute('disabled'), 'disabled', 'O botão de edição deve ser desabilitado');
+
+    const storedTasks = JSON.parse(window.localStorage.getItem('tarefas'));
+    assert(Array.isArray(storedTasks), 'As tarefas persistidas precisam ser um array');
+    assert.strictEqual(storedTasks.length, 1, 'Deve haver exatamente uma tarefa persistida');
+    assert.strictEqual(storedTasks[0].descricao, 'Estudar testes automatizados');
+    assert.strictEqual(storedTasks[0].completa, true, 'A tarefa persistida deve estar marcada como completa');
+  } finally {
+    environment.cleanup();
+    delete require.cache[require.resolve(scriptPath)];
+  }
+});

--- a/tests/helpers/mockDom.js
+++ b/tests/helpers/mockDom.js
@@ -1,0 +1,375 @@
+class MockClassList {
+  constructor(element) {
+    this.element = element;
+    this.classes = new Set();
+  }
+
+  add(...classNames) {
+    classNames.forEach((name) => {
+      if (name) {
+        this.classes.add(name);
+      }
+    });
+    this._sync();
+  }
+
+  remove(...classNames) {
+    classNames.forEach((name) => {
+      if (name) {
+        this.classes.delete(name);
+      }
+    });
+    this._sync();
+  }
+
+  contains(name) {
+    return this.classes.has(name);
+  }
+
+  toggle(name) {
+    if (this.classes.has(name)) {
+      this.classes.delete(name);
+      this._sync();
+      return false;
+    }
+    this.classes.add(name);
+    this._sync();
+    return true;
+  }
+
+  setFromAttribute(value) {
+    this.classes = new Set((value || '').split(/\s+/).filter(Boolean));
+  }
+
+  toString() {
+    return Array.from(this.classes).join(' ');
+  }
+
+  _sync() {
+    const classValue = this.toString();
+    if (classValue) {
+      this.element.attributes.set('class', classValue);
+    } else {
+      this.element.attributes.delete('class');
+    }
+  }
+}
+
+class MockEvent {
+  constructor(type, options = {}) {
+    this.type = type;
+    this.bubbles = Boolean(options.bubbles);
+    this.cancelable = Boolean(options.cancelable);
+    this.defaultPrevented = false;
+    this.target = null;
+    this.currentTarget = null;
+  }
+
+  preventDefault() {
+    if (this.cancelable) {
+      this.defaultPrevented = true;
+    }
+  }
+}
+
+class MockCustomEvent extends MockEvent {
+  constructor(type, options = {}) {
+    super(type, options);
+    this.detail = options.detail;
+  }
+}
+
+class MockElement {
+  constructor(tagName, ownerDocument) {
+    this.tagName = tagName.toUpperCase();
+    this.ownerDocument = ownerDocument;
+    this.children = [];
+    this.parent = null;
+    this.attributes = new Map();
+    this.classList = new MockClassList(this);
+    this.eventListeners = new Map();
+    this.onclick = null;
+    this._textContent = '';
+    this._value = '';
+    this.innerHTML = '';
+  }
+
+  append(...nodes) {
+    nodes.forEach((node) => {
+      if (!(node instanceof MockElement)) {
+        throw new Error('Only MockElement instances can be appended');
+      }
+      if (node.parent) {
+        node.parent.removeChild(node);
+      }
+      node.parent = this;
+      this.children.push(node);
+    });
+  }
+
+  removeChild(child) {
+    const index = this.children.indexOf(child);
+    if (index >= 0) {
+      this.children.splice(index, 1);
+      child.parent = null;
+    }
+  }
+
+  remove() {
+    if (this.parent) {
+      this.parent.removeChild(this);
+    }
+  }
+
+  setAttribute(name, value) {
+    const stringValue = String(value);
+    this.attributes.set(name, stringValue);
+    if (name === 'class') {
+      this.classList.setFromAttribute(stringValue);
+    } else if (name === 'id') {
+      this.id = stringValue;
+    } else if (name === 'disabled') {
+      this.disabled = true;
+    }
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+    if (name === 'id') {
+      this.id = undefined;
+    } else if (name === 'disabled') {
+      this.disabled = false;
+    }
+  }
+
+  hasAttribute(name) {
+    return this.attributes.has(name);
+  }
+
+  addEventListener(type, handler) {
+    if (!this.eventListeners.has(type)) {
+      this.eventListeners.set(type, []);
+    }
+    this.eventListeners.get(type).push(handler);
+  }
+
+  dispatchEvent(event) {
+    if (!event.target) {
+      event.target = this;
+    }
+    event.currentTarget = this;
+    const listeners = this.eventListeners.get(event.type) || [];
+    listeners.forEach((listener) => {
+      listener.call(this, event);
+    });
+    return !event.defaultPrevented;
+  }
+
+  click() {
+    if (typeof this.onclick === 'function') {
+      this.onclick({ target: this });
+    }
+    const listeners = this.eventListeners.get('click') || [];
+    listeners.forEach((listener) => listener.call(this, { target: this, type: 'click' }));
+  }
+
+  matches(selector) {
+    if (selector.startsWith('.')) {
+      return this.classList.contains(selector.slice(1));
+    }
+    if (selector.startsWith('#')) {
+      return this.getAttribute('id') === selector.slice(1);
+    }
+    return this.tagName === selector.toUpperCase();
+  }
+
+  querySelector(selector) {
+    for (const child of this.children) {
+      if (child.matches(selector)) {
+        return child;
+      }
+      const match = child.querySelector(selector);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    const results = [];
+    for (const child of this.children) {
+      if (child.matches(selector)) {
+        results.push(child);
+      }
+      results.push(...child.querySelectorAll(selector));
+    }
+    return results;
+  }
+
+  get textContent() {
+    return this._textContent;
+  }
+
+  set textContent(value) {
+    this._textContent = String(value);
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  set value(value) {
+    this._value = String(value);
+  }
+}
+
+class MockDocument {
+  constructor() {
+    this.body = new MockElement('body', this);
+    this.eventListeners = new Map();
+    this.defaultView = null;
+  }
+
+  createElement(tagName) {
+    return new MockElement(tagName, this);
+  }
+
+  querySelector(selector) {
+    if (this.body.matches(selector)) {
+      return this.body;
+    }
+    return this.body.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    const matches = [];
+    if (this.body.matches(selector)) {
+      matches.push(this.body);
+    }
+    matches.push(...this.body.querySelectorAll(selector));
+    return matches;
+  }
+
+  addEventListener(type, handler) {
+    if (!this.eventListeners.has(type)) {
+      this.eventListeners.set(type, []);
+    }
+    this.eventListeners.get(type).push(handler);
+  }
+
+  dispatchEvent(event) {
+    if (!event.target) {
+      event.target = this;
+    }
+    event.currentTarget = this;
+    const listeners = this.eventListeners.get(event.type) || [];
+    listeners.forEach((listener) => listener.call(this, event));
+    return !event.defaultPrevented;
+  }
+}
+
+class MockLocalStorage {
+  constructor() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return Object.prototype.hasOwnProperty.call(this.store, key) ? this.store[key] : null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  key(index) {
+    const keys = Object.keys(this.store);
+    return keys[index] || null;
+  }
+
+  get length() {
+    return Object.keys(this.store).length;
+  }
+}
+
+class MockWindow {
+  constructor(document) {
+    this.document = document;
+    this.localStorage = new MockLocalStorage();
+    this.Event = MockEvent;
+    this.CustomEvent = MockCustomEvent;
+  }
+}
+
+function buildBaseStructure(document) {
+  const addTaskButton = document.createElement('button');
+  addTaskButton.classList.add('app__button--add-task');
+  document.body.append(addTaskButton);
+
+  const form = document.createElement('form');
+  form.classList.add('app__form-add-task');
+  form.classList.add('hidden');
+  const textarea = document.createElement('textarea');
+  textarea.classList.add('app__form-textarea');
+  form.append(textarea);
+  document.body.append(form);
+
+  const taskList = document.createElement('ul');
+  taskList.classList.add('app__section-task-list');
+  document.body.append(taskList);
+
+  const activeTaskDescription = document.createElement('p');
+  activeTaskDescription.classList.add('app__section-active-task-description');
+  document.body.append(activeTaskDescription);
+
+  const removeCompleted = document.createElement('button');
+  removeCompleted.setAttribute('id', 'btn-remover-concluidas');
+  document.body.append(removeCompleted);
+
+  const removeAll = document.createElement('button');
+  removeAll.setAttribute('id', 'btn-remover-todas');
+  document.body.append(removeAll);
+}
+
+function createDomEnvironment() {
+  const document = new MockDocument();
+  const window = new MockWindow(document);
+  document.defaultView = window;
+  buildBaseStructure(document);
+
+  const applyGlobals = () => {
+    global.window = window;
+    global.document = document;
+    global.localStorage = window.localStorage;
+    global.Event = window.Event;
+    global.CustomEvent = window.CustomEvent;
+  };
+
+  const cleanup = () => {
+    delete global.window;
+    delete global.document;
+    delete global.localStorage;
+    delete global.Event;
+    delete global.CustomEvent;
+  };
+
+  return { window, document, applyGlobals, cleanup };
+}
+
+module.exports = {
+  createDomEnvironment,
+  MockEvent,
+  MockCustomEvent,
+};


### PR DESCRIPTION
## Summary
- add an npm test script that runs a Node-based regression check
- build a lightweight DOM harness to execute script-crud.js logic in isolation
- cover the FocoFinalizado event to confirm it marks and persists the selected task

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a53496bc832ab288ca9a31327390