### PR TITLE
Rename text area constant

### DIFF
--- a/script-crud.js
+++ b/script-crud.js
@@ -1,6 +1,6 @@
 const btnAdicionarTarefa = document.querySelector('.app__button--add-task')
 const formAdicionarTarefa = document.querySelector('.app__form-add-task')
-const textArtea = document.querySelector('.app__form-textarea')
+const textArea = document.querySelector('.app__form-textarea')
 const ulTarefas = document.querySelector('.app__section-task-list')
 const paragrafoDescricaoTarefa = document.querySelector('.app__section-active-task-description')
 
@@ -85,13 +85,13 @@ btnAdicionarTarefa.addEventListener('click', () => {
 formAdicionarTarefa.addEventListener('submit', (evento) => {
     evento.preventDefault();
     const tarefa = {
-        descricao: textArtea.value
+        descricao: textArea.value
     }
     tarefas.push(tarefa)
     const elementoTarefa = criarElementoTarefa(tarefa)
     ulTarefas.append(elementoTarefa)
     atualizarTarefas()
-    textArtea.value = ''
+    textArea.value = ''
     formAdicionarTarefa.classList.add('hidden')
 })
 


### PR DESCRIPTION
## Summary
- rename the textarea constant to use the correct spelling
- update all references so the form submission keeps reading and clearing the textarea

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a6eccad0832a93630d750fb02fc7