### PR TITLE
Ajusta aria-hidden do formulário de tarefas

### DIFF
--- a/script-crud.js
+++ b/script-crud.js
@@ -80,6 +80,8 @@ function criarElementoTarefa(tarefa) {
 
 btnAdicionarTarefa.addEventListener('click', () => {
     formAdicionarTarefa.classList.toggle('hidden')
+    const isHidden = formAdicionarTarefa.classList.contains('hidden')
+    formAdicionarTarefa.setAttribute('aria-hidden', String(isHidden))
 })
 
 formAdicionarTarefa.addEventListener('submit', (evento) => {
@@ -93,6 +95,7 @@ formAdicionarTarefa.addEventListener('submit', (evento) => {
     atualizarTarefas()
     textArtea.value = ''
     formAdicionarTarefa.classList.add('hidden')
+    formAdicionarTarefa.setAttribute('aria-hidden', 'true')
 })
 
 tarefas.forEach(tarefa => {


### PR DESCRIPTION
## Resumo
- atualiza o listener do botão de nova tarefa para manter o atributo aria-hidden sincronizado com a classe hidden
- garante que o formulário defina aria-hidden="true" após o envio e ocultação

## Testes
- não foram necessários testes automatizados

------
https://chatgpt.com/codex/tasks/task_e_68d5a6fc8d34832aacc615c8f26ea7a3