### PR TITLE
Alinha título da tarefa ativa ao cabeçalho de tarefas

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
         <section class="app__section-task-container">
             <div class="app__section-task-content">
                 <header class="app__section-active-task">
-                    <p class="app__section-active-task-label">#Em andamento:</p>
+                    <h2 class="app__section-active-task-label app__section-tasks-heading">#Em andamento:</h2>
                     <p class="app__section-active-task-description"></p>
                 </header>
                 <div class="app__section-task-header">

--- a/styles.css
+++ b/styles.css
@@ -371,11 +371,13 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .app__section-active-task-label {
-    font-family: Montserrat;
-    font-size: 1.25rem;
+    font-family: 'Unbounded', cursive;
+    font-size: 2.6rem;
     font-style: normal;
     font-weight: 400;
-    line-height: 150%;
+    line-height: 120%;
+    color: var(--color-secondary);
+    margin: 0;
 }
 
 .app__section-task-list {


### PR DESCRIPTION
## Resumo
- substitui o parágrafo do rótulo "#Em andamento:" por um heading reutilizando os estilos do cabeçalho de tarefas
- atualiza os estilos da classe `.app__section-active-task-label` para usar a tipografia e cores do título principal

## Testes
- navegação manual em http://127.0.0.1:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68d5ab7f8fe0832a9cc295b1e7c4ded9