### PR TITLE
Align active task display with task list items

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,15 @@
             <div class="app__section-task-content">
                 <header class="app__section-active-task">
                     <p class="app__section-active-task-label">#Em andamento:</p>
-                    <p class="app__section-active-task-description"></p>
+                    <div class="app__section-active-task-card app__section-task-list-item">
+                        <svg class="app__section-task-icon-status" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                            xmlns="http://www.w3.org/2000/svg">
+                            <circle cx="12" cy="12" r="12" fill="#FFF"></circle>
+                            <path d="M9 16.1719L19.5938 5.57812L21 6.98438L9 18.9844L3.42188 13.4062L4.82812 12L9 16.1719Z"
+                                fill="#01080E"></path>
+                        </svg>
+                        <p class="app__section-active-task-description app__section-task-list-item-description"></p>
+                    </div>
                 </header>
                 <div class="app__section-task-header">
                     <h2 class="app__section-tasks-heading">Lista de tarefas:</h2>

--- a/styles.css
+++ b/styles.css
@@ -348,6 +348,13 @@ h1, h2, h3, h4, h5, h6 {
     line-height: 150%;
 }
 
+.app__section-active-task-card {
+    width: 100%;
+    cursor: default;
+    margin-bottom: 0;
+    flex: 1 1 auto;
+}
+
 .app__section-tasks-heading {
     font-size: 2.6rem;
     font-style: normal;


### PR DESCRIPTION
## Summary
- wrap the in-progress task description in a card container with the same status icon used in the task list
- add styling for the active task card so it fills the available space while avoiding pointer affordances

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5ab82d5a4832a8c1b7c9ee78c28f5